### PR TITLE
update resource usage calculation to multiply first and then divide

### DIFF
--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -51,8 +51,8 @@ func (a *AutoScale) autoscaleJob(jobID string, policies map[string]*policy.Group
 		// Maths. Find the current CPU and memory utilisation in percentage based on the total
 		// available resources to the group, compared to their configured maximum based on the
 		// resource stanza.
-		cpuUsage := resourceUsage[group].cpu / resourceInfo[group].cpu * 100
-		memUsage := resourceUsage[group].mem / resourceInfo[group].mem * 100
+		cpuUsage := resourceUsage[group].cpu * 100 / resourceInfo[group].cpu
+		memUsage := resourceUsage[group].mem * 100 / resourceInfo[group].mem
 		a.logger.Debug().
 			Int("mem-usage-percentage", memUsage).
 			Int("cpu-usage-percentage", cpuUsage).


### PR DESCRIPTION
Updating autoscale resource usage % calculation to have multiplication first and then division, so that % usage values don't round to lowest multiple of 100

<!--  Thanks for sending a pull request!  -->

**What type of PR is this?**

Fixing the rounding error that happen during resource utilization calculation for autoscaling. 

**What this PR does / why we need it**:

The PR changes the order of computation for calculating `cpuUsage` and `memUsage` to do the multiplication with 100 first, and then the division, so that % values don't always get rounded to multiples of 100 (0% for usage < 100%, 100% for usage between 100%-200% , 200% for usage between 200% - 300% , and so on) since both `resourceUsage[group].cpu` and `resourceInfo[group].cpu` both appear to be integer constants.

Example logs before the changes:

```
12:54PM DBG resource utilisation calculation cpu-usage-percentage=0 mem-usage-percentage=0
12:54PM INF added group scaling request job=pushgateway scaling-req={"count":1,"direction":"in","group":"pushgateway"}
12:54PM DBG scaling action will break job group minimum threshold group=pushgateway job=pushgateway
12:55PM DBG resource utilisation calculation cpu-usage-percentage=100 mem-usage-percentage=0
12:55PM INF added group scaling request job=pushgateway scaling-req={"count":1,"direction":"in","group":"pushgateway"}
12:55PM DBG scaling action will break job group minimum threshold group=pushgateway job=pushgateway
12:56PM DBG resource utilisation calculation cpu-usage-percentage=0 mem-usage-percentage=0
12:56PM INF added group scaling request job=pushgateway scaling-req={"count":1,"direction":"in","group":"pushgateway"}
12:56PM DBG scaling action will break job group minimum threshold group=pushgateway job=pushgateway
12:57PM DBG resource utilisation calculation cpu-usage-percentage=0 mem-usage-percentage=0
12:57PM INF added group scaling request job=pushgateway scaling-req={"count":1,"direction":"in","group":"pushgateway"}
12:57PM DBG scaling action will break job group minimum threshold group=pushgateway job=pushgateway
12:58PM DBG resource utilisation calculation cpu-usage-percentage=0 mem-usage-percentage=0
12:58PM INF added group scaling request job=pushgateway scaling-req={"count":1,"direction":"in","group":"pushgateway"}
12:58PM DBG scaling action will break job group minimum threshold group=pushgateway job=pushgateway
12:59PM DBG resource utilisation calculation cpu-usage-percentage=200 mem-usage-percentage=0
12:59PM INF added group scaling request job=pushgateway scaling-req={"count":1,"direction":"in","group":"pushgateway"}
12:59PM DBG scaling action will break job group minimum threshold group=pushgateway job=pushgateway
```

**Which issue(s) this PR fixes**:

Fixes #
https://github.com/jrasell/sherpa/issues/13

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
