### PR TITLE
Filter out the allocations from ResourceTracker that aren't actively running or pending

### DIFF
--- a/pkg/autoscale/autoscale.go
+++ b/pkg/autoscale/autoscale.go
@@ -109,6 +109,10 @@ func (a *AutoScale) getJobAllocations(jobID string, policies map[string]*policy.
 			break
 		}
 
+		if !(allocs[i].ClientStatus == "running" || allocs[i].ClientStatus == "pending") {
+			continue
+		}
+
 		allocInfo, _, err := a.nomad.Allocations().Info(allocs[i].ID, nil)
 		if err != nil {
 			return out, nil, err


### PR DESCRIPTION
**What type of PR is this?**

Filter out allocs that are not in either `running` or `pending` state from getting added to the resource tracker used for autoscaling calculations.

**What this PR does / why we need it**:

The autoscaler was triggering the scaling behavior unexpectedly, since it was adding the resource allocations and last captured resource utilization (RSS mem and CPU ticks) from allocs that have completed or failed. As we don't want such allocs affecting the computation used in determining the elasticity for a nomad job group, we are only trying to look at allocs that are either in `running` or `pending` state to determine the current state of the job group resources.

Example logs before the changes, after adding a debug statement in the `getJobResourceUsage` function right after `a.nomad.Allocations().Stats(allocs[i], nil)` is called:
```
a.logger.Debug().
    Int("cpu", int(stats.ResourceUsage.CpuStats.TotalTicks)).
    Int("memory", int(stats.ResourceUsage.MemoryStats.RSS/1024/1024)).
    Msg("Usage")
```
```
 DBG Reading policy from meta
2:34PM DBG Read policy from meta
2:35PM DBG Usage CPU: 0, Memory: 0
2:35PM DBG Usage CPU: 0, Memory: 0
2:35PM DBG Usage CPU: 0, Memory: 0
2:35PM DBG Usage CPU: 0, Memory: 0
2:35PM DBG Usage CPU: 0, Memory: 0
2:35PM DBG Usage CPU: 0, Memory: 0
2:35PM DBG Usage CPU: 23, Memory: 7
2:35PM DBG Usage CPU: 112, Memory: 8
2:35PM DBG Usage CPU: 5, Memory: 7
2:35PM DBG resource utilisation calculation cpu-usage-percentage=77 mem-usage-percentage=10
2:35PM INF added group scaling request job=pushgateway scaling-req={"count":1,"direction":"out","group":"pushgateway"}
2:35PM DBG scaling action will break job group maximum threshold group=pushgateway job=pushgateway

```
We expected to only see one `DBG` line `DBG Usage CPU: 23, Memory: 7`, as there was only one actively running allocation at the time. But we saw a line corresponding to all allocations that were also marked `failed` or `completed`. The Nomad GC doesn't collect these allocations quickly and they stick around for some time and can affect the resource utilization calculations.

**Which issue(s) this PR fixes**:

Fixes #
https://github.com/jrasell/sherpa/issues/14

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
